### PR TITLE
Add Alembic migration for task retry tracking

### DIFF
--- a/MIGRATION_TESTS.py
+++ b/MIGRATION_TESTS.py
@@ -1,0 +1,133 @@
+"""Safety checks for Alembic migrations."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import sqlalchemy as sa
+from alembic import command
+from alembic.config import Config
+
+PROJECT_ROOT = Path(__file__).resolve().parent
+ALEMBIC_CONFIG = PROJECT_ROOT / "alembic.ini"
+
+
+def _alembic_config(database_url: str) -> Config:
+    cfg = Config(str(ALEMBIC_CONFIG))
+    cfg.set_main_option("script_location", "alembic")
+    cfg.set_main_option("sqlalchemy.url", database_url)
+    return cfg
+
+
+def _get_engine(url: str) -> sa.Engine:
+    return sa.create_engine(url, future=True)
+
+
+@pytest.fixture()
+def temp_db(tmp_path: Path) -> str:
+    db_file = tmp_path / "taskrunnerx.sqlite"
+    return f"sqlite:///{db_file}"
+
+
+def _legacy_schema_metadata() -> sa.MetaData:
+    metadata = sa.MetaData()
+    sa.Table(
+        "tasks",
+        metadata,
+        sa.Column("id", sa.Integer, primary_key=True, nullable=False),
+        sa.Column("name", sa.String(128), nullable=False),
+        sa.Column("status", sa.String(32), nullable=False, server_default="queued"),
+        sa.Column("payload", sa.JSON, nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.text("CURRENT_TIMESTAMP")),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("started_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("finished_at", sa.DateTime(timezone=True), nullable=True),
+    )
+    return metadata
+
+
+def _get_columns(engine: sa.Engine, table: str) -> set[str]:
+    inspector = sa.inspect(engine)
+    return {column["name"] for column in inspector.get_columns(table)}
+
+
+def _get_indexes(engine: sa.Engine, table: str) -> set[str]:
+    inspector = sa.inspect(engine)
+    return {index["name"] for index in inspector.get_indexes(table)}
+
+
+def test_upgrade_and_downgrade_clean_database(temp_db: str) -> None:
+    cfg = _alembic_config(temp_db)
+    command.upgrade(cfg, "head")
+
+    engine = _get_engine(temp_db)
+    inspector = sa.inspect(engine)
+    assert "tasks" in inspector.get_table_names()
+    columns = _get_columns(engine, "tasks")
+    expected_columns = {
+        "id",
+        "name",
+        "status",
+        "payload",
+        "attempts",
+        "last_error",
+        "created_at",
+        "updated_at",
+        "started_at",
+        "finished_at",
+    }
+    assert expected_columns <= columns
+    indexes = _get_indexes(engine, "tasks")
+    assert {"ix_tasks_name", "ix_tasks_status"} <= indexes
+
+    command.downgrade(cfg, "base")
+    inspector = sa.inspect(_get_engine(temp_db))
+    assert "tasks" not in inspector.get_table_names()
+
+
+def test_upgrade_and_downgrade_legacy_snapshot(temp_db: str) -> None:
+    engine = _get_engine(temp_db)
+    metadata = _legacy_schema_metadata()
+    metadata.create_all(engine)
+    tasks = metadata.tables["tasks"]
+    with engine.begin() as conn:
+        conn.execute(
+            tasks.insert(),
+            [
+                {
+                    "name": "echo",
+                    "status": "queued",
+                    "payload": {"message": "hello"},
+                }
+            ],
+        )
+
+    engine.dispose()
+
+    cfg = _alembic_config(temp_db)
+    command.upgrade(cfg, "head")
+
+    engine = _get_engine(temp_db)
+    columns = _get_columns(engine, "tasks")
+    assert {"attempts", "last_error"} <= columns
+    with engine.begin() as conn:
+        result = conn.execute(sa.text("SELECT attempts, last_error FROM tasks"))
+        attempts, last_error = result.first()
+    assert attempts == 0
+    assert last_error is None
+    indexes = _get_indexes(engine, "tasks")
+    assert {"ix_tasks_name", "ix_tasks_status"} <= indexes
+
+    command.downgrade(cfg, "base")
+
+    engine = _get_engine(temp_db)
+    inspector = sa.inspect(engine)
+    assert "tasks" in inspector.get_table_names()
+    columns = _get_columns(engine, "tasks")
+    assert "attempts" not in columns
+    assert "last_error" not in columns
+    with engine.begin() as conn:
+        result = conn.execute(sa.text("SELECT name, status FROM tasks"))
+        row = result.first()
+    assert row == ("echo", "queued")

--- a/alembic.ini
+++ b/alembic.ini
@@ -1,0 +1,39 @@
+[alembic]
+script_location = alembic
+sqlalchemy.url = sqlite:///./taskrunnerx.db
+
+disable_environment_context = false
+
+download_directory = .
+
+[loggers]
+keys = root,sqlalchemy,alembic
+
+[handlers]
+keys = console
+
+[formatters]
+keys = generic
+
+[logger_root]
+level = WARN
+handlers = console
+
+[logger_sqlalchemy]
+level = WARN
+handlers =
+qualname = sqlalchemy.engine
+
+[logger_alembic]
+level = INFO
+handlers =
+qualname = alembic
+
+[handler_console]
+class = StreamHandler
+args = (sys.stderr,)
+level = NOTSET
+formatter = generic
+
+[formatter_generic]
+format = %(levelname)-5.5s [%(name)s] %(message)s

--- a/alembic/README
+++ b/alembic/README
@@ -1,0 +1,1 @@
+Generic single-database configuration for Alembic migrations.

--- a/alembic/env.py
+++ b/alembic/env.py
@@ -1,0 +1,85 @@
+"""Alembic environment configuration."""
+
+from __future__ import annotations
+
+import os
+from logging.config import fileConfig
+
+from alembic import context
+from sqlalchemy import engine_from_config, pool
+
+from taskrunnerx.app.db import Base
+
+# this is the Alembic Config object, which provides
+# access to the values within the .ini file in use.
+config = context.config
+
+if config.config_file_name is not None:
+    fileConfig(config.config_file_name)
+
+
+def _get_sqlalchemy_url() -> str:
+    """Resolve the database URL for migrations."""
+
+    override = os.getenv("ALEMBIC_SQLALCHEMY_URL")
+    if override:
+        return override
+    url = config.get_main_option("sqlalchemy.url")
+    if url:
+        return url
+    raise RuntimeError("SQLAlchemy URL is not configured for Alembic")
+
+
+target_metadata = Base.metadata
+
+
+def run_migrations_offline() -> None:
+    """Run migrations in 'offline' mode."""
+
+    url = _get_sqlalchemy_url()
+    context.configure(
+        url=url,
+        target_metadata=target_metadata,
+        literal_binds=True,
+        dialect_opts={"paramstyle": "named"},
+        compare_type=True,
+        compare_server_default=True,
+    )
+
+    with context.begin_transaction():
+        context.run_migrations()
+
+
+def run_migrations_online() -> None:
+    """Run migrations in 'online' mode."""
+
+    configuration = config.get_section(config.config_ini_section) or {}
+    configuration["sqlalchemy.url"] = _get_sqlalchemy_url()
+    connectable = engine_from_config(
+        configuration,
+        prefix="sqlalchemy.",
+        poolclass=pool.NullPool,
+    )
+
+    with connectable.connect() as connection:
+        context.configure(
+            connection=connection,
+            target_metadata=target_metadata,
+            compare_type=True,
+            compare_server_default=True,
+        )
+
+        with context.begin_transaction():
+            context.run_migrations()
+
+
+def run_migrations() -> None:
+    """Entrypoint invoked by Alembic."""
+
+    if context.is_offline_mode():
+        run_migrations_offline()
+    else:
+        run_migrations_online()
+
+
+run_migrations()

--- a/alembic/versions/20241102_01_add_task_attempts_last_error.py
+++ b/alembic/versions/20241102_01_add_task_attempts_last_error.py
@@ -1,0 +1,112 @@
+"""Add attempts tracking and error storage to tasks."""
+
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = "20241102_01"
+down_revision = None
+branch_labels = None
+depends_on = None
+
+_TASKS_TABLE = "tasks"
+
+
+def _ensure_tasks_table() -> None:
+    """Create the tasks table if it does not yet exist."""
+
+    op.create_table(
+        _TASKS_TABLE,
+        sa.Column("id", sa.Integer(), primary_key=True, nullable=False),
+        sa.Column("name", sa.String(length=128), nullable=False),
+        sa.Column("status", sa.String(length=32), nullable=False, server_default=sa.text("'queued'")),
+        sa.Column("payload", sa.JSON(), nullable=True),
+        sa.Column("attempts", sa.Integer(), nullable=False, server_default=sa.text("0")),
+        sa.Column("last_error", sa.Text(), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.text("CURRENT_TIMESTAMP")),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("started_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("finished_at", sa.DateTime(timezone=True), nullable=True),
+        mysql_charset="utf8mb4",
+        mysql_collate="utf8mb4_unicode_ci",
+    )
+    op.create_index("ix_tasks_name", _TASKS_TABLE, ["name"], unique=False)
+    op.create_index("ix_tasks_status", _TASKS_TABLE, ["status"], unique=False)
+
+
+def _ensure_columns(inspector: sa.Inspector) -> None:
+    """Ensure newly added columns exist and are populated."""
+
+    existing_columns = {column["name"] for column in inspector.get_columns(_TASKS_TABLE)}
+    bind = op.get_bind()
+
+    if "attempts" not in existing_columns:
+        op.add_column(
+            _TASKS_TABLE,
+            sa.Column("attempts", sa.Integer(), nullable=False, server_default=sa.text("0")),
+        )
+        bind.execute(sa.text("UPDATE tasks SET attempts = 0 WHERE attempts IS NULL"))
+    else:
+        bind.execute(sa.text("UPDATE tasks SET attempts = 0 WHERE attempts IS NULL"))
+        op.alter_column(
+            _TASKS_TABLE,
+            "attempts",
+            existing_type=sa.Integer(),
+            nullable=False,
+        )
+
+    if "last_error" not in existing_columns:
+        op.add_column(_TASKS_TABLE, sa.Column("last_error", sa.Text(), nullable=True))
+
+
+def _ensure_indexes(inspector: sa.Inspector) -> None:
+    """Create required indexes when missing."""
+
+    existing_indexes = {index["name"] for index in inspector.get_indexes(_TASKS_TABLE)}
+    if "ix_tasks_name" not in existing_indexes:
+        op.create_index("ix_tasks_name", _TASKS_TABLE, ["name"], unique=False)
+    if "ix_tasks_status" not in existing_indexes:
+        op.create_index("ix_tasks_status", _TASKS_TABLE, ["status"], unique=False)
+
+
+def upgrade() -> None:
+    """Apply the schema changes for task retries and error capture."""
+
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    table_names = inspector.get_table_names()
+
+    if _TASKS_TABLE not in table_names:
+        _ensure_tasks_table()
+        return
+
+    _ensure_columns(inspector)
+    _ensure_indexes(inspector)
+
+
+def downgrade() -> None:
+    """Revert the schema changes introduced in this revision."""
+
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    table_names = inspector.get_table_names()
+    if _TASKS_TABLE not in table_names:
+        return
+
+    existing_indexes = {index["name"] for index in inspector.get_indexes(_TASKS_TABLE)}
+    if "ix_tasks_status" in existing_indexes:
+        op.drop_index("ix_tasks_status", table_name=_TASKS_TABLE)
+    if "ix_tasks_name" in existing_indexes:
+        op.drop_index("ix_tasks_name", table_name=_TASKS_TABLE)
+
+    existing_columns = {column["name"] for column in inspector.get_columns(_TASKS_TABLE)}
+    if "last_error" in existing_columns:
+        op.drop_column(_TASKS_TABLE, "last_error")
+    if "attempts" in existing_columns:
+        op.drop_column(_TASKS_TABLE, "attempts")
+
+    row_count = bind.execute(sa.text("SELECT COUNT(*) FROM tasks")).scalar_one()
+    if row_count == 0:
+        op.drop_table(_TASKS_TABLE)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ redis = "5.3.1"
 apscheduler = "3.11.0"
 python-dotenv = "1.1.1"
 requests = "2.32.5"
+alembic = "1.14.0"
 
 [tool.poetry.group.dev.dependencies]
 black = "24.10.0"

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ redis==5.3.1
 apscheduler==3.11.0
 python-dotenv==1.1.1
 requests==2.32.5
+alembic==1.14.0


### PR DESCRIPTION
## Summary
- add Alembic configuration and dependency wiring to support database migrations
- ensure the tasks table gains the attempts counter, last_error column, and required indexes via a resilient migration
- cover upgrade/downgrade behaviour on clean and legacy schemas with automated migration safety tests

## Testing
- pytest MIGRATION_TESTS.py

------
https://chatgpt.com/codex/tasks/task_e_68e4ef076b308332b2589af0b37beb3b