### PR TITLE
Add idempotent execution pipeline with retries and metrics

### DIFF
--- a/alembic/versions/20241108_01_idempotent_tasks.py
+++ b/alembic/versions/20241108_01_idempotent_tasks.py
@@ -1,0 +1,128 @@
+"""Add idempotent execution metadata and supporting tables."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from datetime import UTC, datetime
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "20241108_01"
+down_revision = "20241102_01_add_task_attempts_last_error"
+branch_labels = None
+depends_on = None
+
+
+def _hash_payload(payload: dict[str, object] | None) -> str:
+    normalized = json.dumps(payload or {}, sort_keys=True, separators=(",", ":"))
+    return hashlib.sha256(normalized.encode("utf-8")).hexdigest()
+
+
+def _window_start(ts: datetime, window_ms: int = 60000) -> datetime:
+    epoch_ms = int(ts.timestamp() * 1000)
+    bucket = epoch_ms // window_ms
+    aligned = bucket * window_ms
+    return datetime.fromtimestamp(aligned / 1000, tz=UTC)
+
+
+def upgrade() -> None:
+    op.add_column("tasks", sa.Column("payload_hash", sa.String(length=128), nullable=True))
+    op.add_column("tasks", sa.Column("scheduled_at", sa.DateTime(timezone=True), nullable=True))
+    op.add_column(
+        "tasks",
+        sa.Column("scheduled_window_start", sa.DateTime(timezone=True), nullable=True),
+    )
+    op.add_column(
+        "tasks",
+        sa.Column("execution_key", sa.String(length=256), nullable=True),
+    )
+
+    connection = op.get_bind()
+    tasks = sa.table(
+        "tasks",
+        sa.column("id", sa.Integer),
+        sa.column("name", sa.String(128)),
+        sa.column("payload", sa.JSON),
+        sa.column("created_at", sa.DateTime(timezone=True)),
+        sa.column("payload_hash", sa.String(128)),
+        sa.column("scheduled_at", sa.DateTime(timezone=True)),
+        sa.column("scheduled_window_start", sa.DateTime(timezone=True)),
+        sa.column("execution_key", sa.String(256)),
+    )
+
+    rows = list(connection.execute(sa.select(tasks.c.id, tasks.c.name, tasks.c.payload, tasks.c.created_at)))
+    now = datetime.now(tz=UTC)
+    for row in rows:
+        scheduled_at = row.created_at or now
+        payload_hash = _hash_payload(row.payload)
+        window_start = _window_start(scheduled_at)
+        execution_key = f"legacy:{row.id}"
+        connection.execute(
+            tasks.update()
+            .where(tasks.c.id == row.id)
+            .values(
+                payload_hash=payload_hash,
+                scheduled_at=scheduled_at,
+                scheduled_window_start=window_start,
+                execution_key=execution_key,
+            )
+        )
+
+    op.alter_column("tasks", "payload_hash", existing_type=sa.String(length=128), nullable=False)
+    op.alter_column("tasks", "scheduled_at", existing_type=sa.DateTime(timezone=True), nullable=False)
+    op.alter_column(
+        "tasks",
+        "scheduled_window_start",
+        existing_type=sa.DateTime(timezone=True),
+        nullable=False,
+    )
+    op.alter_column("tasks", "execution_key", existing_type=sa.String(length=256), nullable=False)
+    op.create_unique_constraint("uq_tasks_execution_key", "tasks", ["execution_key"])
+
+    op.create_table(
+        "task_outbox",
+        sa.Column("id", sa.Integer, primary_key=True),
+        sa.Column("task_id", sa.Integer, sa.ForeignKey("tasks.id", ondelete="CASCADE"), nullable=False, unique=True),
+        sa.Column("stream", sa.String(length=128), nullable=False),
+        sa.Column("execution_key", sa.String(length=256), nullable=False),
+        sa.Column("payload", sa.JSON, nullable=False, server_default=sa.text("'{}'")),
+        sa.Column("available_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("sent_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("stream_id", sa.String(length=128), nullable=True),
+        sa.Column("delivery_attempts", sa.Integer, nullable=False, server_default="0"),
+    )
+
+    op.create_table(
+        "task_inbox",
+        sa.Column("id", sa.Integer, primary_key=True),
+        sa.Column("task_id", sa.Integer, sa.ForeignKey("tasks.id", ondelete="CASCADE"), nullable=False, unique=True),
+        sa.Column("execution_key", sa.String(length=256), nullable=False, unique=True),
+        sa.Column("attempts", sa.Integer, nullable=False, server_default="0"),
+        sa.Column("last_seen_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("processed_at", sa.DateTime(timezone=True), nullable=True),
+    )
+
+    op.create_table(
+        "task_dead_letter",
+        sa.Column("id", sa.Integer, primary_key=True),
+        sa.Column("task_id", sa.Integer, sa.ForeignKey("tasks.id", ondelete="CASCADE"), nullable=False),
+        sa.Column("execution_key", sa.String(length=256), nullable=False),
+        sa.Column("name", sa.String(length=128), nullable=False),
+        sa.Column("payload", sa.JSON, nullable=False, server_default=sa.text("'{}'")),
+        sa.Column("error", sa.Text, nullable=False),
+        sa.Column("failed_at", sa.DateTime(timezone=True), nullable=False),
+        sa.UniqueConstraint("task_id", "execution_key", name="uq_dead_letter_task"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("task_dead_letter")
+    op.drop_table("task_inbox")
+    op.drop_table("task_outbox")
+    op.drop_constraint("uq_tasks_execution_key", "tasks", type_="unique")
+    op.drop_column("tasks", "execution_key")
+    op.drop_column("tasks", "scheduled_window_start")
+    op.drop_column("tasks", "scheduled_at")
+    op.drop_column("tasks", "payload_hash")

--- a/taskrunnerx/app/config.py
+++ b/taskrunnerx/app/config.py
@@ -21,10 +21,22 @@ class Settings(BaseModel):
     redis_url: str = Field(default=os.getenv("REDIS_URL", "redis://localhost:6379/0"))
     redis_stream: str = Field(default=os.getenv("REDIS_STREAM", "trx.tasks"))
     redis_group: str = Field(default=os.getenv("REDIS_GROUP", "trx.workers"))
+    redis_dlq_stream: str = Field(default=os.getenv("REDIS_DLQ_STREAM", "trx.tasks.dlq"))
 
     # * Scheduler
     scheduler_enabled: bool = Field(
         default=os.getenv("SCHEDULER_ENABLED", "true").casefold() == "true"
+    )
+
+    # * Task execution safety
+    dedupe_window_ms: int = Field(
+        default=int(os.getenv("TASK_DEDUPE_WINDOW_MS", "60000")), ge=1
+    )
+    clock_skew_ms: int = Field(default=int(os.getenv("TASK_CLOCK_SKEW_MS", "500")), ge=0)
+    max_task_attempts: int = Field(default=int(os.getenv("TASK_MAX_ATTEMPTS", "5")), ge=1)
+    retry_backoff_ms: int = Field(default=int(os.getenv("TASK_RETRY_BACKOFF_MS", "500")), ge=0)
+    retry_backoff_multiplier: float = Field(
+        default=float(os.getenv("TASK_RETRY_BACKOFF_MULTIPLIER", "2.0")), ge=1.0
     )
 
     # * Misc

--- a/taskrunnerx/app/models.py
+++ b/taskrunnerx/app/models.py
@@ -1,8 +1,9 @@
 from datetime import datetime
 from typing import Any
 
-from sqlalchemy import DateTime, Integer, JSON, String, Text
-from sqlalchemy.orm import Mapped, mapped_column
+from sqlalchemy import DateTime, ForeignKey, Integer, JSON, String, Text, UniqueConstraint
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+from typing import Optional
 from sqlalchemy.sql import func
 
 from .db import Base
@@ -17,8 +18,14 @@ class Task(Base):
     name: Mapped[str] = mapped_column(String(128), index=True, nullable=False)
     status: Mapped[str] = mapped_column(String(32), index=True, nullable=False, default="queued")
     payload: Mapped[dict[str, Any] | None] = mapped_column(JSON, nullable=True)
+    payload_hash: Mapped[str] = mapped_column(String(128), nullable=False)
     attempts: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
     last_error: Mapped[str | None] = mapped_column(Text, nullable=True)
+    scheduled_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
+    scheduled_window_start: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False
+    )
+    execution_key: Mapped[str] = mapped_column(String(256), nullable=False, unique=True)
 
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True),
@@ -30,3 +37,63 @@ class Task(Base):
     )
     started_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
     finished_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+
+    outbox: Mapped[Optional["TaskOutbox"]] = relationship(
+        "TaskOutbox", back_populates="task", cascade="all, delete-orphan", uselist=False
+    )
+    inbox: Mapped[Optional["TaskInbox"]] = relationship(
+        "TaskInbox", back_populates="task", cascade="all, delete-orphan", uselist=False
+    )
+    dead_letter: Mapped[list["TaskDeadLetter"]] = relationship(
+        "TaskDeadLetter", back_populates="task", cascade="all, delete-orphan"
+    )
+
+
+class TaskOutbox(Base):
+    __tablename__ = "task_outbox"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    task_id: Mapped[int] = mapped_column(
+        Integer, ForeignKey("tasks.id", ondelete="CASCADE"), unique=True, nullable=False
+    )
+    stream: Mapped[str] = mapped_column(String(128), nullable=False)
+    execution_key: Mapped[str] = mapped_column(String(256), nullable=False)
+    payload: Mapped[dict[str, Any]] = mapped_column(JSON, nullable=False, default=dict)
+    available_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
+    sent_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    stream_id: Mapped[str | None] = mapped_column(String(128), nullable=True)
+    delivery_attempts: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+
+    task: Mapped[Task] = relationship("Task", back_populates="outbox")
+
+
+class TaskInbox(Base):
+    __tablename__ = "task_inbox"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    task_id: Mapped[int] = mapped_column(
+        Integer, ForeignKey("tasks.id", ondelete="CASCADE"), unique=True, nullable=False
+    )
+    execution_key: Mapped[str] = mapped_column(String(256), nullable=False, unique=True)
+    attempts: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    last_seen_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    processed_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+
+    task: Mapped[Task] = relationship("Task", back_populates="inbox")
+
+
+class TaskDeadLetter(Base):
+    __tablename__ = "task_dead_letter"
+    __table_args__ = (UniqueConstraint("task_id", "execution_key", name="uq_dead_letter_task"),)
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    task_id: Mapped[int] = mapped_column(
+        Integer, ForeignKey("tasks.id", ondelete="CASCADE"), nullable=False
+    )
+    execution_key: Mapped[str] = mapped_column(String(256), nullable=False)
+    name: Mapped[str] = mapped_column(String(128), nullable=False)
+    payload: Mapped[dict[str, Any]] = mapped_column(JSON, nullable=False, default=dict)
+    error: Mapped[str] = mapped_column(Text, nullable=False)
+    failed_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
+
+    task: Mapped[Task] = relationship("Task", back_populates="dead_letter")

--- a/taskrunnerx/app/schemas.py
+++ b/taskrunnerx/app/schemas.py
@@ -7,6 +7,7 @@ from pydantic import BaseModel, Field
 class TaskCreate(BaseModel):
     name: str = Field(..., min_length=1, max_length=128)
     payload: dict[str, Any] | None = None
+    scheduled_at: datetime | None = None
 
 
 class TaskRead(BaseModel):
@@ -14,12 +15,16 @@ class TaskRead(BaseModel):
     name: str
     status: str
     payload: dict[str, Any] | None = None
+    payload_hash: str
     attempts: int
     last_error: str | None = None
     created_at: datetime
     updated_at: datetime | None = None
     started_at: datetime | None = None
     finished_at: datetime | None = None
+    scheduled_at: datetime
+    scheduled_window_start: datetime
+    execution_key: str
 
     class Config:
         from_attributes = True

--- a/taskrunnerx/app/services/queue.py
+++ b/taskrunnerx/app/services/queue.py
@@ -1,17 +1,45 @@
+"""Redis-backed task queue with outbox/inbox safety."""
+
+from __future__ import annotations
+
+import asyncio
+from contextlib import contextmanager
+from datetime import UTC, datetime
 import json
-from typing import Any, cast
+from typing import Any, Callable, cast
 
 from redis import asyncio as aioredis
+from sqlalchemy import select
+from sqlalchemy.orm import Session
 
 from ..config import get_settings
+from ..db import SessionLocal
+from ...metrics import metrics
+from ..models import Task, TaskDeadLetter, TaskOutbox
 
 settings = get_settings()
 
 
 class Queue:
-    def __init__(self) -> None:
+    """Wrapper around Redis streams with transactional outbox dispatch."""
+
+    def __init__(self, session_factory: Callable[[], Session] = SessionLocal) -> None:
         self._redis: aioredis.Redis | None = None
         self.stream = settings.redis_stream
+        self.dlq_stream = settings.redis_dlq_stream
+        self._session_factory = session_factory
+
+    @contextmanager
+    def _session_scope(self) -> Session:
+        session = self._session_factory()
+        try:
+            yield session
+            session.commit()
+        except Exception:
+            session.rollback()
+            raise
+        finally:
+            session.close()
 
     async def connect(self) -> None:
         if not self._redis:
@@ -26,33 +54,119 @@ class Queue:
             await self._redis.close()
             self._redis = None
 
-    async def enqueue(
-        self,
-        task_id: int,
-        name: str,
-        payload: dict[str, Any] | None = None,
+    async def _publish(
+        self, stream: str, payload: dict[str, str], maxlen: int = 10000
     ) -> str:
         await self.connect()
-        data: dict[str, str] = {
-            "task_id": str(task_id),
-            "name": name,
-            "payload": json.dumps(payload or {}),
-        }
-
         redis = self._redis
         if redis is None:
             msg = "Redis connection not established"
             raise RuntimeError(msg)
-
-        # * XADD for Redis Streams
-        fields = cast(dict[Any, Any], data)
-        result = await redis.xadd(
-            self.stream,
-            fields=fields,
-            maxlen=10000,
-            approximate=True,
-        )
+        fields = cast(dict[Any, Any], payload)
+        result = await redis.xadd(stream, fields=fields, maxlen=maxlen, approximate=True)
         return cast(str, result)
+
+    async def dispatch_task(self, task_id: int) -> str:
+        """Push a persisted task to Redis if due, respecting idempotency."""
+
+        stream_id = ""
+        now = datetime.now(tz=UTC)
+
+        with self._session_scope() as db:
+            stmt = (
+                select(TaskOutbox, Task)
+                .join(Task, Task.id == TaskOutbox.task_id)
+                .where(TaskOutbox.task_id == task_id)
+                .with_for_update()
+            )
+            result = db.execute(stmt).one_or_none()
+            if not result:
+                msg = f"Outbox entry for task {task_id} not found"
+                raise LookupError(msg)
+            outbox, task = result
+            if outbox.stream_id:
+                return outbox.stream_id
+            available_at = outbox.available_at
+            if available_at.tzinfo is None:
+                available_at = available_at.replace(tzinfo=UTC)
+            if available_at > now:
+                return ""
+
+            message = {
+                "task_id": str(task_id),
+                "name": task.name,
+                "payload": json.dumps(task.payload or {}),
+                "execution_key": outbox.execution_key,
+                "scheduled_at": task.scheduled_at.isoformat(),
+                "attempt": str(task.attempts + 1),
+            }
+
+            stream_id = await self._publish(self.stream, message)
+            outbox.sent_at = datetime.now(tz=UTC)
+            outbox.stream_id = stream_id
+            outbox.delivery_attempts += 1
+            metrics.increment("attempts")
+            db.add(outbox)
+
+        return stream_id
+
+    async def flush_due(self, limit: int = 25) -> list[str]:
+        """Flush all due outbox entries."""
+
+        dispatched: list[str] = []
+        while True:
+            now = datetime.now(tz=UTC)
+            with self._session_scope() as db:
+                stmt = (
+                    select(TaskOutbox, Task)
+                    .join(Task, Task.id == TaskOutbox.task_id)
+                    .where(TaskOutbox.sent_at.is_(None))
+                    .with_for_update(skip_locked=True)
+                    .limit(limit)
+                )
+                rows = db.execute(stmt).all()
+                if not rows:
+                    break
+                for outbox, task in rows:
+                    available_at = outbox.available_at
+                    if available_at.tzinfo is None:
+                        available_at = available_at.replace(tzinfo=UTC)
+                    if available_at > now:
+                        continue
+                    message = {
+                        "task_id": str(task.id),
+                        "name": task.name,
+                        "payload": json.dumps(task.payload or {}),
+                        "execution_key": outbox.execution_key,
+                        "scheduled_at": task.scheduled_at.isoformat(),
+                        "attempt": str(task.attempts + 1),
+                    }
+                    stream_id = await self._publish(self.stream, message)
+                    outbox.sent_at = datetime.now(tz=UTC)
+                    outbox.stream_id = stream_id
+                    outbox.delivery_attempts += 1
+                    metrics.increment("attempts")
+                    db.add(outbox)
+                    dispatched.append(stream_id)
+            if len(dispatched) < limit:
+                break
+        return dispatched
+
+    async def requeue_with_delay(self, task_id: int, delay_seconds: float) -> None:
+        await asyncio.sleep(delay_seconds)
+        await self.dispatch_task(task_id)
+
+    async def publish_dead_letter(self, record: TaskDeadLetter) -> str:
+        payload = {
+            "task_id": str(record.task_id),
+            "execution_key": record.execution_key,
+            "name": record.name,
+            "payload": json.dumps(record.payload or {}),
+            "error": record.error,
+            "failed_at": record.failed_at.isoformat(),
+        }
+        stream_id = await self._publish(self.dlq_stream, payload)
+        return stream_id
 
 
 queue = Queue()

--- a/taskrunnerx/app/services/tasks.py
+++ b/taskrunnerx/app/services/tasks.py
@@ -1,49 +1,204 @@
-from datetime import datetime, UTC
+from __future__ import annotations
+
+from collections.abc import Iterable
+from datetime import UTC, datetime, timedelta
+import hashlib
+import json
 from typing import Any
 
-from sqlalchemy import select
+from sqlalchemy import and_, select
 from sqlalchemy.orm import Session
 
-from ..models import Task
+from ..config import get_settings
+from ..models import Task, TaskDeadLetter, TaskInbox, TaskOutbox
 from ..schemas import TaskCreate
 
 """
 Implements a task management system
 """
 
+SETTINGS = get_settings()
 
-def create_task(db: Session, data: TaskCreate) -> Task:
+
+def _normalize_payload(payload: dict[str, Any]) -> str:
+    return json.dumps(payload, sort_keys=True, separators=(",", ":"))
+
+
+def compute_payload_hash(payload: dict[str, Any]) -> str:
+    normalized = _normalize_payload(payload)
+    return hashlib.sha256(normalized.encode("utf-8")).hexdigest()
+
+
+def _window_candidates(scheduled_at: datetime) -> list[datetime]:
+    window_ms = SETTINGS.dedupe_window_ms
+    skew = SETTINGS.clock_skew_ms
+    epoch_ms = int(scheduled_at.timestamp() * 1000)
+
+    def _align(ms: int) -> datetime:
+        bucket = ms // window_ms
+        aligned = bucket * window_ms
+        return datetime.fromtimestamp(aligned / 1000, tz=UTC)
+
+    base = _align(epoch_ms)
+    candidates = {base}
+    if skew:
+        candidates.add(_align(epoch_ms + skew))
+        candidates.add(_align(epoch_ms - skew))
+    ordered = [base]
+    for candidate in sorted(candidates - {base}):
+        ordered.append(candidate)
+    return ordered
+
+
+def compute_execution_key(name: str, payload_hash: str, window_start: datetime) -> str:
+    return f"{name}:{payload_hash}:{int(window_start.timestamp() * 1000)}"
+
+
+def _existing_task(
+    db: Session, name: str, payload_hash: str, candidate_windows: Iterable[datetime]
+) -> Task | None:
+    stmt = (
+        select(Task)
+        .where(
+            and_(
+                Task.name == name,
+                Task.payload_hash == payload_hash,
+                Task.scheduled_window_start.in_(list(candidate_windows)),
+            )
+        )
+        .limit(1)
+    )
+    return db.scalar(stmt)
+
+
+def create_task(db: Session, data: TaskCreate) -> tuple[Task, bool]:
     payload: dict[str, Any] = data.payload or {}
-    task = Task(name=data.name, payload=payload, status="queued")
+    payload_hash = compute_payload_hash(payload)
+    scheduled_at = data.scheduled_at or datetime.now(tz=UTC)
+    candidate_windows = _window_candidates(scheduled_at)
+    existing = _existing_task(db, data.name, payload_hash, candidate_windows)
+    if existing:
+        return existing, False
+
+    window_start = candidate_windows[0]
+    execution_key = compute_execution_key(data.name, payload_hash, window_start)
+    task = Task(
+        name=data.name,
+        payload=payload,
+        payload_hash=payload_hash,
+        status="queued",
+        scheduled_at=scheduled_at,
+        scheduled_window_start=window_start,
+        execution_key=execution_key,
+    )
     db.add(task)
     db.flush()
-    return task
+    outbox = TaskOutbox(
+        task_id=task.id,
+        stream=SETTINGS.redis_stream,
+        execution_key=execution_key,
+        payload=payload,
+        available_at=scheduled_at,
+    )
+    db.add(outbox)
+    return task, True
 
 
-def set_task_started(db: Session, task_id: int) -> Task | None:
+def set_task_started(db: Session, task_id: int, execution_key: str) -> Task | None:
     q = select(Task).where(Task.id == task_id)
     task = db.scalar(q)
     if not task:
+        return None
+    if task.execution_key != execution_key:
+        return None
+    if task.inbox and task.inbox.processed_at:
         return None
     task.status = "running"
     task.started_at = datetime.now(tz=UTC)
     task.attempts += 1
     db.add(task)
+    inbox = task.inbox or TaskInbox(task_id=task.id, execution_key=task.execution_key)
+    if inbox.attempts is None:
+        inbox.attempts = 0
+    inbox.attempts += 1
+    inbox.last_seen_at = datetime.now(tz=UTC)
+    task.inbox = inbox
     return task
 
 
-def set_task_finished(db: Session, task_id: int, error: str | None = None) -> Task | None:
+def set_task_finished(
+    db: Session, task_id: int, execution_key: str, error: str | None = None
+) -> Task | None:
     q = select(Task).where(Task.id == task_id)
     task = db.scalar(q)
     if not task:
+        return None
+    if task.execution_key != execution_key:
         return None
 
     task.status = "failed" if error else "done"
     task.finished_at = datetime.now(tz=UTC)
     if error:
         task.last_error = error
+    if task.inbox:
+        if error is None:
+            task.inbox.processed_at = task.finished_at
+        task.inbox.last_seen_at = task.finished_at
     db.add(task)
     return task
+
+
+def mark_task_retry(
+    db: Session,
+    task_id: int,
+    execution_key: str,
+    delay: timedelta,
+    error: str,
+    max_attempts: int,
+) -> tuple[bool, int]:
+    task = db.get(Task, task_id)
+    if not task:
+        return False, 0
+    if task.execution_key != execution_key:
+        return False, task.attempts
+
+    attempts = task.attempts
+    if attempts >= max_attempts:
+        return False, attempts
+
+    next_run = datetime.now(tz=UTC) + delay
+    task.status = "retrying"
+    task.last_error = error
+    task.scheduled_at = next_run
+    task.scheduled_window_start = _window_candidates(next_run)[0]
+    if task.outbox:
+        task.outbox.sent_at = None
+        task.outbox.stream_id = None
+        task.outbox.available_at = next_run
+    db.add(task)
+    return True, attempts
+
+
+def move_to_dead_letter(
+    db: Session, task_id: int, execution_key: str, name: str, payload: dict[str, Any], error: str
+) -> TaskDeadLetter:
+    task = db.get(Task, task_id)
+    failed_at = datetime.now(tz=UTC)
+    if task:
+        task.status = "dead_letter"
+        task.last_error = error
+        task.finished_at = failed_at
+        db.add(task)
+    dlq = TaskDeadLetter(
+        task_id=task_id,
+        execution_key=execution_key,
+        name=name,
+        payload=payload,
+        error=error,
+        failed_at=failed_at,
+    )
+    db.add(dlq)
+    return dlq
 
 
 def get_task(db: Session, task_id: int) -> Task | None:

--- a/taskrunnerx/logging.py
+++ b/taskrunnerx/logging.py
@@ -1,22 +1,55 @@
 """Logging configuration."""
 
 import logging
+from logging import Logger
 import sys
+from typing import Any
+
+from contextvars import ContextVar
 
 from .app.config import get_settings
+
+TRACE_ID: ContextVar[str] = ContextVar("trace_id", default="-")
+SPAN_ID: ContextVar[str] = ContextVar("span_id", default="-")
+
+
+class ContextFilter(logging.Filter):
+    def filter(self, record: logging.LogRecord) -> bool:  # noqa: D401 - logging hook
+        record.trace_id = TRACE_ID.get("-")
+        record.span_id = SPAN_ID.get("-")
+        return True
 
 
 def setup_logging() -> None:
     """Setup application logging."""
 
     settings = get_settings()
-    logging.basicConfig(
-        level=getattr(logging, settings.log_level.upper()),
-        format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
-        handlers=[logging.StreamHandler(sys.stdout)],
+    if logging.getLogger().handlers:
+        return
+    handler = logging.StreamHandler(sys.stdout)
+    handler.setFormatter(
+        logging.Formatter(
+            "%(asctime)s - %(name)s - %(levelname)s - trace=%(trace_id)s span=%(span_id)s %(message)s"
+        )
     )
+    handler.addFilter(ContextFilter())
+    root = logging.getLogger()
+    root.setLevel(getattr(logging, settings.log_level.upper()))
+    root.addHandler(handler)
 
 
-def get_logger(name: str) -> logging.Logger:
+def get_logger(name: str) -> Logger:
     """Get logger instance."""
     return logging.getLogger(name)
+
+
+def set_trace_context(trace_id: str, span_id: str) -> tuple[Any, Any]:
+    trace_token = TRACE_ID.set(trace_id)
+    span_token = SPAN_ID.set(span_id)
+    return trace_token, span_token
+
+
+def reset_trace_context(tokens: tuple[Any, Any]) -> None:
+    trace_token, span_token = tokens
+    TRACE_ID.reset(trace_token)
+    SPAN_ID.reset(span_token)

--- a/taskrunnerx/metrics.py
+++ b/taskrunnerx/metrics.py
@@ -13,6 +13,7 @@ class Metrics:
 
     counters: defaultdict[str, int] = field(default_factory=lambda: defaultdict(int))
     timers: defaultdict[str, list[float]] = field(default_factory=lambda: defaultdict(list))
+    gauges: dict[str, float] = field(default_factory=dict)
 
     def increment(self, metric: str, value: int = 1) -> None:
         """Increment counter metric."""
@@ -22,8 +23,16 @@ class Metrics:
         """Record timer metric."""
         self.timers[metric].append(duration)
 
+    def set_gauge(self, metric: str, value: float) -> None:
+        """Set gauge metric."""
+        self.gauges[metric] = value
+
     def get_stats(self) -> dict[str, Any]:
         """Get all metrics."""
+        success = self.counters.get("tasks_success", 0)
+        failure = self.counters.get("tasks_failure", 0)
+        total = success + failure
+        success_rate = (success / total) if total else 0.0
         return {
             "counters": dict(self.counters),
             "timers": {
@@ -33,6 +42,10 @@ class Metrics:
                     "total": sum(values),
                 }
                 for key, values in self.timers.items()
+            },
+            "gauges": dict(self.gauges),
+            "derived": {
+                "success_rate": success_rate,
             },
         }
 

--- a/taskrunnerx/scheduler/scheduler.py
+++ b/taskrunnerx/scheduler/scheduler.py
@@ -4,17 +4,30 @@ import signal
 from apscheduler.schedulers.asyncio import AsyncIOScheduler
 from apscheduler.triggers.interval import IntervalTrigger
 
+from taskrunnerx.app.deps import db_session
+from taskrunnerx.app.schemas import TaskCreate
 from taskrunnerx.app.services.queue import queue
+from taskrunnerx.app.services.tasks import create_task
 
 
 async def enqueue_heartbeat() -> None:
-    await queue.enqueue(task_id=0, name="heartbeat", payload={"source": "scheduler"})
+    with db_session() as db:
+        task, _ = create_task(
+            db,
+            TaskCreate(name="heartbeat", payload={"source": "scheduler"}),
+        )
+    await queue.dispatch_task(task.id)
+
+
+async def flush_due_tasks() -> None:
+    await queue.flush_due()
 
 
 async def main() -> None:
     await queue.connect()
     scheduler = AsyncIOScheduler(timezone="UTC")
     scheduler.add_job(enqueue_heartbeat, trigger=IntervalTrigger(minutes=1))
+    scheduler.add_job(flush_due_tasks, trigger=IntervalTrigger(seconds=5))
     scheduler.start()
 
     stop = asyncio.Event()

--- a/taskrunnerx/worker/logging.py
+++ b/taskrunnerx/worker/logging.py
@@ -1,13 +1,44 @@
 import logging
 from logging import Logger
 import sys
+from typing import Any
+
+from contextvars import ContextVar
+
+
+TRACE_ID: ContextVar[str] = ContextVar("trace_id", default="-")
+SPAN_ID: ContextVar[str] = ContextVar("span_id", default="-")
+
+
+class ContextFilter(logging.Filter):
+    def filter(self, record: logging.LogRecord) -> bool:  # noqa: D401 - logging hook
+        record.trace_id = TRACE_ID.get("-")
+        record.span_id = SPAN_ID.get("-")
+        return True
 
 
 def setup_logging(level: str = "INFO") -> Logger:
     logger = logging.getLogger("worker")
     logger.setLevel(level)
-    handler = logging.StreamHandler(sys.stdout)
-    handler.setFormatter(logging.Formatter("[%(asctime)s] %(levelname)s %(message)s"))
-    logger.addHandler(handler)
-    logger.propagate = False
+    if not logger.handlers:
+        handler = logging.StreamHandler(sys.stdout)
+        formatter = logging.Formatter(
+            "[%(asctime)s] %(levelname)s trace=%(trace_id)s span=%(span_id)s %(message)s"
+        )
+        handler.setFormatter(formatter)
+        handler.addFilter(ContextFilter())
+        logger.addHandler(handler)
+        logger.propagate = False
     return logger
+
+
+def set_trace_context(trace_id: str, span_id: str) -> tuple[Any, Any]:
+    trace_token = TRACE_ID.set(trace_id)
+    span_token = SPAN_ID.set(span_id)
+    return trace_token, span_token
+
+
+def reset_trace_context(tokens: tuple[Any, Any]) -> None:
+    trace_token, span_token = tokens
+    TRACE_ID.reset(trace_token)
+    SPAN_ID.reset(span_token)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,109 @@
+from __future__ import annotations
+
+from collections.abc import Iterator
+from pathlib import Path
+import sys
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session, sessionmaker
+
+from taskrunnerx.app.db import Base
+from taskrunnerx.app.services import tasks as tasks_service
+from taskrunnerx.app.services.queue import Queue as QueueService
+from taskrunnerx.app.services.queue import settings as queue_settings
+from taskrunnerx.metrics import metrics
+from taskrunnerx.worker import worker as worker_module
+
+
+@pytest.fixture()
+def sqlite_engine(tmp_path: Path) -> Iterator[Session]:
+    db_file = tmp_path / "taskrunnerx.sqlite"
+    engine = create_engine(f"sqlite:///{db_file}", future=True)
+    Base.metadata.create_all(engine)
+    try:
+        yield engine
+    finally:
+        Base.metadata.drop_all(engine)
+        engine.dispose()
+
+
+@pytest.fixture()
+def session_factory(sqlite_engine) -> sessionmaker[Session]:
+    return sessionmaker(bind=sqlite_engine, autoflush=False, autocommit=False, future=True)
+
+
+@pytest.fixture(autouse=True)
+def tune_settings() -> Iterator[None]:
+    original = {
+        "dedupe_window_ms": tasks_service.SETTINGS.dedupe_window_ms,
+        "clock_skew_ms": tasks_service.SETTINGS.clock_skew_ms,
+        "max_task_attempts": tasks_service.SETTINGS.max_task_attempts,
+        "retry_backoff_ms": tasks_service.SETTINGS.retry_backoff_ms,
+        "retry_backoff_multiplier": tasks_service.SETTINGS.retry_backoff_multiplier,
+    }
+    queue_original = {
+        "dedupe_window_ms": queue_settings.dedupe_window_ms,
+        "clock_skew_ms": queue_settings.clock_skew_ms,
+        "max_task_attempts": queue_settings.max_task_attempts,
+        "retry_backoff_ms": queue_settings.retry_backoff_ms,
+        "retry_backoff_multiplier": queue_settings.retry_backoff_multiplier,
+    }
+    worker_original = {
+        "max_task_attempts": worker_module.SETTINGS.max_task_attempts,
+        "retry_backoff_ms": worker_module.SETTINGS.retry_backoff_ms,
+        "retry_backoff_multiplier": worker_module.SETTINGS.retry_backoff_multiplier,
+    }
+    tasks_service.SETTINGS.dedupe_window_ms = 1000
+    tasks_service.SETTINGS.clock_skew_ms = 100
+    tasks_service.SETTINGS.max_task_attempts = 3
+    tasks_service.SETTINGS.retry_backoff_ms = 10
+    tasks_service.SETTINGS.retry_backoff_multiplier = 2.0
+    queue_settings.dedupe_window_ms = tasks_service.SETTINGS.dedupe_window_ms
+    queue_settings.clock_skew_ms = tasks_service.SETTINGS.clock_skew_ms
+    queue_settings.max_task_attempts = tasks_service.SETTINGS.max_task_attempts
+    queue_settings.retry_backoff_ms = tasks_service.SETTINGS.retry_backoff_ms
+    queue_settings.retry_backoff_multiplier = (
+        tasks_service.SETTINGS.retry_backoff_multiplier
+    )
+    worker_module.SETTINGS.max_task_attempts = tasks_service.SETTINGS.max_task_attempts
+    worker_module.SETTINGS.retry_backoff_ms = tasks_service.SETTINGS.retry_backoff_ms
+    worker_module.SETTINGS.retry_backoff_multiplier = (
+        tasks_service.SETTINGS.retry_backoff_multiplier
+    )
+    try:
+        yield
+    finally:
+        for key, value in original.items():
+            setattr(tasks_service.SETTINGS, key, value)
+        for key, value in queue_original.items():
+            setattr(queue_settings, key, value)
+        for key, value in worker_original.items():
+            setattr(worker_module.SETTINGS, key, value)
+
+
+@pytest.fixture(autouse=True)
+def reset_metrics() -> Iterator[None]:
+    metrics.counters.clear()
+    metrics.timers.clear()
+    metrics.gauges.clear()
+    try:
+        yield
+    finally:
+        metrics.counters.clear()
+        metrics.timers.clear()
+        metrics.gauges.clear()
+
+
+@pytest.fixture()
+def queue(session_factory: sessionmaker[Session]) -> QueueService:
+    return QueueService(session_factory=session_factory)
+
+
+@pytest.fixture()
+def anyio_backend() -> str:
+    return "asyncio"

--- a/tests/test_integration_retry.py
+++ b/tests/test_integration_retry.py
@@ -1,0 +1,115 @@
+from __future__ import annotations
+
+import asyncio
+from contextlib import contextmanager
+from datetime import UTC, datetime
+from typing import Any
+
+import pytest
+
+from taskrunnerx.app.models import Task, TaskDeadLetter
+from taskrunnerx.app.schemas import TaskCreate
+from taskrunnerx.app.services import tasks as tasks_service
+from taskrunnerx.worker import worker as worker_module
+
+
+class FakeRedis:
+    def __init__(self) -> None:
+        self.entries: list[tuple[str, dict[str, Any]]] = []
+        self.acks: list[tuple[str, str, str]] = []
+
+    async def xadd(self, stream: str, fields: dict[str, Any], **_: Any) -> str:
+        entry_id = f"{len(self.entries)}-0"
+        self.entries.append((entry_id, fields))
+        return entry_id
+
+    async def xack(self, stream: str, group: str, msg_id: str) -> None:
+        self.acks.append((stream, group, msg_id))
+
+    async def xinfo_groups(self, stream: str) -> list[dict[str, Any]]:  # pragma: no cover - unused
+        return []
+
+    async def xgroup_create(
+        self, stream: str, group: str, id: str = "$", mkstream: bool = True
+    ) -> None:  # pragma: no cover - unused
+        return None
+
+
+@pytest.mark.anyio("asyncio")
+async def test_retry_flow_is_idempotent(session_factory, queue) -> None:
+    fake_redis = FakeRedis()
+
+    async def fake_connect() -> None:
+        queue._redis = fake_redis
+
+    queue.connect = fake_connect  # type: ignore[assignment]
+    queue._redis = fake_redis
+    original_queue = worker_module.queue
+    worker_module.queue = queue
+    worker_module.SETTINGS.retry_backoff_ms = 0
+    original_db_session = worker_module.db_session
+
+    @contextmanager
+    def worker_session() -> Any:
+        session = session_factory()
+        try:
+            yield session
+            session.commit()
+        except Exception:
+            session.rollback()
+            raise
+        finally:
+            session.close()
+
+    worker_module.db_session = worker_session
+
+    call_count = 0
+
+    async def flaky_task(payload: dict[str, Any]) -> None:
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            raise RuntimeError("boom")
+
+    original_handler = worker_module.HANDLERS.get("flaky")
+    worker_module.HANDLERS["flaky"] = flaky_task
+
+    scheduled_at = datetime.now(tz=UTC)
+    with session_factory() as session:
+        task, _ = tasks_service.create_task(
+            session, TaskCreate(name="flaky", payload={"n": 1}, scheduled_at=scheduled_at)
+        )
+        session.commit()
+        task_id = task.id
+
+    await queue.dispatch_task(task_id)
+    assert len(fake_redis.entries) == 1
+    entry_id, fields = fake_redis.entries[0]
+
+    try:
+        await worker_module.handle_message(fake_redis, entry_id, fields)
+        await asyncio.sleep(0.01)
+        assert call_count == 1
+        assert len(fake_redis.entries) >= 2
+
+        retry_entry_id, retry_fields = fake_redis.entries[-1]
+        await worker_module.handle_message(fake_redis, retry_entry_id, retry_fields)
+
+        assert call_count == 2
+        assert len(fake_redis.acks) == 2
+
+        with session_factory() as session:
+            db_task = session.get(Task, task_id)
+            assert db_task is not None
+            assert db_task.status == "done"
+            assert db_task.attempts == 2
+            assert db_task.inbox is not None
+            assert db_task.inbox.processed_at is not None
+            assert session.query(TaskDeadLetter).count() == 0
+    finally:
+        if original_handler is not None:
+            worker_module.HANDLERS["flaky"] = original_handler
+        else:
+            worker_module.HANDLERS.pop("flaky", None)
+        worker_module.queue = original_queue
+        worker_module.db_session = original_db_session

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -1,0 +1,105 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+from taskrunnerx.app.models import Task
+from taskrunnerx.app.schemas import TaskCreate
+from taskrunnerx.app.services import tasks as tasks_service
+
+
+def test_payload_hash_is_order_invariant() -> None:
+    payload_a = {"a": 1, "b": 2}
+    payload_b = {"b": 2, "a": 1}
+    assert tasks_service.compute_payload_hash(payload_a) == tasks_service.compute_payload_hash(
+        payload_b
+    )
+
+
+def test_create_task_deduplicates_within_clock_skew(session_factory) -> None:
+    scheduled_at = datetime.now(tz=UTC)
+    skew = tasks_service.SETTINGS.clock_skew_ms - 10
+    request = TaskCreate(name="echo", payload={"msg": "hi"}, scheduled_at=scheduled_at)
+    with session_factory() as session:
+        task, created = tasks_service.create_task(session, request)
+        session.commit()
+        first_id = task.id
+    assert created
+
+    second_request = TaskCreate(
+        name="echo",
+        payload={"msg": "hi"},
+        scheduled_at=scheduled_at + timedelta(milliseconds=skew),
+    )
+    with session_factory() as session:
+        duplicate, created_second = tasks_service.create_task(session, second_request)
+        session.commit()
+        duplicate_id = duplicate.id
+
+    assert not created_second
+    assert duplicate_id == first_id
+
+
+def test_create_task_generates_unique_execution_key(session_factory) -> None:
+    scheduled_at = datetime.now(tz=UTC)
+    first = TaskCreate(name="echo", payload={"seq": 1}, scheduled_at=scheduled_at)
+    second = TaskCreate(
+        name="echo",
+        payload={"seq": 1},
+        scheduled_at=scheduled_at + timedelta(milliseconds=tasks_service.SETTINGS.dedupe_window_ms),
+    )
+
+    with session_factory() as session:
+        task_one, created_one = tasks_service.create_task(session, first)
+        session.commit()
+        key_one = task_one.execution_key
+    with session_factory() as session:
+        task_two, created_two = tasks_service.create_task(session, second)
+        session.commit()
+        key_two = task_two.execution_key
+
+    assert created_one
+    assert created_two
+    assert key_one != key_two
+
+
+def test_mark_task_retry_respects_max_attempts(session_factory) -> None:
+    scheduled_at = datetime.now(tz=UTC)
+    request = TaskCreate(name="echo", payload={"msg": "retry"}, scheduled_at=scheduled_at)
+    with session_factory() as session:
+        task, _ = tasks_service.create_task(session, request)
+        session.commit()
+        task_id = task.id
+        execution_key = task.execution_key
+
+    with session_factory() as session:
+        should_retry, attempts = tasks_service.mark_task_retry(
+            session,
+            task_id,
+            execution_key,
+            delay=timedelta(seconds=1),
+            error="boom",
+            max_attempts=3,
+        )
+        session.commit()
+    assert should_retry
+    assert attempts == 0
+
+    with session_factory() as session:
+        db_task = session.get(Task, task_id)
+        assert db_task is not None
+        db_task.attempts = 3
+        session.add(db_task)
+        session.commit()
+
+    with session_factory() as session:
+        should_retry_again, attempts_again = tasks_service.mark_task_retry(
+            session,
+            task_id,
+            execution_key,
+            delay=timedelta(seconds=1),
+            error="boom",
+            max_attempts=3,
+        )
+        session.commit()
+    assert not should_retry_again
+    assert attempts_again == 3

--- a/tests/test_worker_purity.py
+++ b/tests/test_worker_purity.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+import copy
+
+import pytest
+
+from taskrunnerx.worker.worker import HANDLERS
+
+
+@pytest.mark.anyio("asyncio")
+async def test_task_handlers_preserve_payload_inputs() -> None:
+    sample_payloads = [
+        {"text": "hello"},
+        {"source": "scheduler"},
+        {"value": 42},
+    ]
+
+    for handler in HANDLERS.values():
+        for payload in sample_payloads:
+            snapshot = copy.deepcopy(payload)
+            await handler(copy.deepcopy(payload))
+            assert payload == snapshot


### PR DESCRIPTION
## Summary
- extend the task schema with execution metadata and add transactional outbox, inbox, and dead-letter tables guarded by a new migration and migration tests
- implement idempotent task submission, exponential backoff with dead-letter routing, enhanced metrics, and trace-aware logging for workers and queue dispatch
- expose a metrics endpoint and add scheduler support for flushing due tasks, plus a comprehensive test suite covering hashing, dedupe, retries, concurrency, and handler purity

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e62aa9b8dc8332a54ee5940698528b